### PR TITLE
chore(): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "appsec"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "patch"
+        - "minor"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,19 +12,19 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pipenv
-        pipenv sync --dev
-    - name: Test with unittest
-      run: |
-        pipenv run test
-    - name: Lint with ruff
-      run: |
-        pipenv run lint
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pipenv
+          pipenv sync --dev
+      - name: Test with unittest
+        run: |
+          pipenv run test
+      - name: Lint with ruff
+        run: |
+          pipenv run lint


### PR DESCRIPTION
# Pin GitHub Actions to commit SHAs

## Description of change

Pins all third-party GitHub Actions to specific commit SHAs to protect
against tag hijacking / supply chain attacks. Actions from the `rewindio`
org are excluded and remain at their original version refs.

Uses [ratchet](https://github.com/sethvargo/ratchet) for SHA resolution.

## Testing Performed
